### PR TITLE
(#10) added a check for settings to be null

### DIFF
--- a/src/Cake.Android.Adb.Tests/AdbPackageManagerTests.cs
+++ b/src/Cake.Android.Adb.Tests/AdbPackageManagerTests.cs
@@ -3,6 +3,7 @@ using Cake.AndroidAdb.Fakes;
 using System.Linq;
 using System;
 using System.IO;
+using Cake.Testing;
 
 namespace Cake.AndroidAdb.Tests
 {
@@ -73,6 +74,15 @@ namespace Cake.AndroidAdb.Tests
 
 			Assert.NotNull(path);
 			Assert.True(path.FullPath == "/system/priv-app/DownloadProvider/DownloadProvider.apk");
+		}
+
+		[Fact]
+		// https://github.com/cake-contrib/Cake.Android.Adb/issues/10
+		public void Settings_Is_Null_Does_Not_Throw()
+		{ 
+			Action action = () => Cake.PmPathToPackage("com.android.providers.downloads", settings: null);
+
+			Assert.Throws<FileNotFoundException>(action);
 		}
 	}
 }


### PR DESCRIPTION
in GetAlternativeToolPaths

<!--- Provide a general summary of your changes in the Title above -->

## Description
When calling an alias without settings being set and without having `adb` in path an "Object reference not set to an instance of an object" is thrown. This is due to `settings.SdkRoot` being used without being checked whether either was set.

## Related Issue
#10

## Motivation and Context
#10

## How Has This Been Tested?
I added a unit test to test this

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
